### PR TITLE
Require sudden change in value increase

### DIFF
--- a/LightSensor/app/src/main/res/layout/activity_sensing.xml
+++ b/LightSensor/app/src/main/res/layout/activity_sensing.xml
@@ -22,7 +22,7 @@
         android:id="@+id/sensor_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/lights_on"
+        android:text="@string/lights_off"
         android:textSize="30sp"
         app:layout_constraintEnd_toEndOf="@+id/img_light"
         app:layout_constraintHorizontal_bias="0.532"


### PR DESCRIPTION
- For lights to be considered turned on, a quick increase needs to happen

For example:
Sensor event 1: 30 lx
Sensor event 2: 34 lx
Sensor event 3: 38 lx
**Gradual increase, not sudden**

Sensor event 1: 30 lx
Sensor event 2: 70 lx
**Sudden increase**