### PR TITLE
Fix callback in simple_alarm

### DIFF
--- a/SmartAlarm/simple_alarm.py
+++ b/SmartAlarm/simple_alarm.py
@@ -12,7 +12,7 @@ from bleak import BleakClient
 class Timer():
     def __init__(self):
 
-        self.client = BleClient(self.test_callback)
+        self.client = BleClient(self.sensor_callback)
         loop = asyncio.get_event_loop()
             
  #      winsound.PlaySound("soundalarm.wav",  winsound.SND_ASYNC)  #Alarm sound, this should play until if(test_callback()) return True
@@ -30,7 +30,7 @@ class Timer():
         print("Stopping client")
         await self.client.stop()
         
-    async def test_callback(self, value):
+    def sensor_callback(self, value):
         if(value):
             print("Lights are on")  #Start task here or start in the init
             


### PR DESCRIPTION
Callback was defined as async function while it was being called non-asynchronously. Also renamed the function since original "test_callback" was used for testing that BLE worked in the first place